### PR TITLE
added basePath command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ like this:
         "title": "Overridden title",
         "description": "Overridden description"
       },
-      "host": "exaple.com"
+      "host": "example.com"
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,32 @@ based on your Serverless project structure.
 
 First install the plugin into your Serverless project:
 
+```
     npm install --save serverless-plugin-swagger-export
+```
 
 Then edit your **s-project.json**, locate the plugins: [] section, and add
 the plugin as follows:
 
+```js
     plugins: [
         "serverless-plugin-swagger-export"
     ]
+```
 
 ## Usage
 
 To autogenerate a Swagger JSON API definition, use this command:
 
-    sls swagger export
+```
+    sls swagger export [-b <basePath>]
+```
+
+where supplying `basePath` will set a default basePath tag in Swagger. 
+This is useful if you are using different stages in Serverless, as you can 
+set the stage name as the basePath in your CI/CD tool.  NOTE: You can still 
+set `basePath` inside s-project.json, and this will take precedence over 
+the command line option - see below for customising exported API documentation.
 
 ## Customizing exported API documentation
 
@@ -34,6 +46,7 @@ Swagger JSON.
 In **s-project.json**, you can override top level Swagger JSON elements
 like this:
 
+```
     "name": "MyServerlessProject",
     "version": "1.0.0",
     "swaggerExport": {
@@ -41,14 +54,16 @@ like this:
         "title": "Overridden title",
         "description": "Overridden description"
       },
-      "host": "example.com"
+      "host": "exaple.com"
     }
+```
 
 Any elements you specify under swaggerExport will replace the defaults.
 
 In **s-function.json**, you can add Swagger documentation to each endpoint
 like this:
 
+```
     "path": "myapi",
     "method": "GET",
     "type": "AWS",
@@ -61,6 +76,22 @@ like this:
       "parameters": [],
       "responses": {}
     }
+```
+
+### Excluding endpoints from Swagger
+
+if you wish an endpoint to be excluded (for instance, OPTIONS endpoints, or functions with no endpoints at all), simply set the only swagger tag as 'exclude':
+```
+    "path": "myapi",
+    "method": "OPTIONS",
+    "type": "AWS",
+    "authorizationType": "none",
+    "apiKeyRequired": true,
+    "swaggerExport": {
+      "exclude": true,
+    }
+```
+
 
 Please see Swagger documentation for more details on all the fields.
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,11 @@ module.exports = function(S) {
         description:    'Exports a Swagger JSON API definition to standard output',
         context:        'swagger',
         contextAction:  'export',
-        options:        [],
+        options:       [{ 
+          option:      'basePath',
+          shortcut:    'b',
+          description: 'Supplied basePath will be used unless overridden in s-project.json'
+        }],
         parameters:     []
       });
       return BbPromise.resolve();
@@ -72,9 +76,16 @@ module.exports = function(S) {
     /**
      * This function exports the Swagger JSON to stdout
      */
-    _exportSwaggerJSON() {
+    _exportSwaggerJSON(evt) {
+
       // This is the base Swagger JSON
       var project = S.getProject();
+
+      let basePath = '/';
+      if (evt.options.basePath) {
+        basePath += evt.options.basePath;
+      }
+
       var swagger = {
         "swagger": "2.0",
         "info": {
@@ -83,7 +94,7 @@ module.exports = function(S) {
           "description": project.description
         },
         "host": "localhost",
-        "basePath": "/",
+        "basePath": basePath,
         "schemes": ["http"],
         "tags": [],
         "securityDefinitions": {},

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "serverless-plugin-swagger-export",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "engines": {
     "node": ">=4.0"
   },
   "description": "Swagger Export plugin for Serverless",
-  "author": "Kenneth Falck <kennu@iki.fi>",
+  "author": {
+    "name": "Kenneth Falck",
+    "email": "kennu@iki.fi"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -26,5 +29,5 @@
   },
   "dependencies": {
     "bluebird": "^3.0.6"
-  }
+ }
 }


### PR DESCRIPTION
We use the stage name in serverless as part of our API url (it's the basePath). As we want to use Jenkins to deliver our code to AWS automatically, we need to update the basePath per stage, automatically. So I've made a change to be able to set a default basePath from the command line. See the readme changes for a another (better?!) explanation.

I think this is the best option to be able to set the base path on the fly. The other option would be to update the plugin to be aware of serverless stage variables and interpolate any variables found in the s-project.json.. however this is much more of a rewrite.

I also updated the readme to highlight that you can exlude functions from swagger.

Hope you like it and will merge the change :)
